### PR TITLE
Changes related to RTP SDES header extension

### DIFF
--- a/draft-ietf-mmusic-sdp-bundle-negotiation.txt
+++ b/draft-ietf-mmusic-sdp-bundle-negotiation.txt
@@ -153,11 +153,11 @@ Internet-Draft                Bundled media                  August 2016
             3264 . . . . . . . . . . . . . . . . . . . . . . . . . .  26
    14. RTP/RTCP extensions for identification-tag transport  . . . .  27
      14.1.  RTCP MID SDES Item . . . . . . . . . . . . . . . . . . .  28
-     14.2.  RTP MID Header Extension . . . . . . . . . . . . . . . .  28
-   15. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  28
+     14.2.  RTP SDES Header Extension For MID  . . . . . . . . . . .  28
+   15. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  29
      15.1.  New SDES item  . . . . . . . . . . . . . . . . . . . . .  29
-     15.2.  New RTP Header Extension URI . . . . . . . . . . . . . .  29
-     15.3.  New SDP Attribute  . . . . . . . . . . . . . . . . . . .  29
+     15.2.  New RTP SDES Header Extension URI  . . . . . . . . . . .  29
+     15.3.  New SDP Attribute  . . . . . . . . . . . . . . . . . . .  30
      15.4.  New SDP Group Semantics  . . . . . . . . . . . . . . . .  30
    16. Security Considerations . . . . . . . . . . . . . . . . . . .  30
    17. Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .  31
@@ -324,8 +324,8 @@ Internet-Draft                Bundled media                  August 2016
    "m=" line, carries an unique identification-tag.  The session-level
    SDP 'group' attribute [RFC5888] carries a list of identification-
    tags, identifying the "m=" lines associated with that particular
-   'group' attribute.
-
+   'group' attribute.  The identification-tag value MUST be chosen so
+   that it does not reveal user or application information.
 
 
 
@@ -1467,17 +1467,23 @@ Internet-Draft                Bundled media                  August 2016
 
    This section defines a new RTCP SDES item [RFC3550], 'MID', which is
    used to carry identification-tags within RTCP SDES packets.  This
-   section also defines a new RTP header extension [RFC5285], which is
-   used to carry identification-tags in RTP packets.
+   section also defines a new RTP SDES header extension
+   [I-D.ietf-avtext-sdes-hdr-ext], which is used to carry the 'MID' RTCP
+   SDES item in RTP packets.
 
-   The SDES item and RTP header extension make it possible for a
+   The SDES item and RTP SDES header extension make it possible for a
    receiver to associate received RTCP- and RTP packets with a specific
    "m=" line, with which the receiver has associated an identification-
-   tag, even if those "m=" lines are part of the same RTP session.  A
-   media recipient informs the media sender about the identification-tag
-   associated with an "m=" line through the use of an 'mid' attribute
-   [RFC5888].  The media sender then inserts the identification-tag in
-   RTCP and RTP packets sent to the media recipient.
+   tag, even if those "m=" lines are part of the same RTP session.  The
+   RTP SDES header extension also ensures that the media recipient gets
+   the identification-tag upon receipt of the first decodable media and
+   is able to associate the media with the correct application.
+
+   A media recipient informs the media sender about the identification-
+   tag associated with an "m=" line through the use of an 'mid'
+   attribute [RFC5888].  The media sender then inserts the
+   identification-tag in RTCP and RTP packets sent to the media
+   recipient.
 
    NOTE: This text above defines how identification-tags are carried in
    SDP Offers and Answers.  The usage of other signalling protocols for
@@ -1492,20 +1498,14 @@ Internet-Draft                Bundled media                  August 2016
    depend on the expected packet loss rate, the RTCP reporting interval,
    and the allowable overhead.
 
-   The RTP MID header extension SHOULD be included in some RTP packets
-   at the start of the session and whenever the SSRC changes.  It might
-   also be useful to include the header extension in RTP packets that
-   comprise access points in the media (e.g., with video I-frames).  The
-   exact number of RTP packets in which this header extension is sent is
-   intentionally not specified here, as it will depend on expected
-   packet loss rate and loss patterns, the overhead the application can
-   tolerate, and the importance of immediate receipt of the
-   identification-tag.
+   The RTP SDES header extension for carrying the 'MID' RTCP SDES SHOULD
+   be included in some RTP packets at the start of the session and
+   whenever the SSRC changes.  It might also be useful to include the
+   header extension in RTP packets that comprise access points in the
+   media (e.g., with video I-frames).  The exact number of RTP packets
+   in which this header extension is sent is intentionally not specified
+   here, as it will depend on expected packet loss rate and loss
 
-   For robustness purpose, endpoints need to be prepared for situations
-   where the reception of the identification-tag is delayed, and SHOULD
-   NOT terminate sessions in such cases, as the identification-tag is
-   likely to arrive soon.
 
 
 
@@ -1513,6 +1513,14 @@ Holmberg, et al.        Expires February 12, 2017              [Page 27]
 
 Internet-Draft                Bundled media                  August 2016
 
+
+   patterns, the overhead the application can tolerate, and the
+   importance of immediate receipt of the identification-tag.
+
+   For robustness purpose, endpoints need to be prepared for situations
+   where the reception of the identification-tag is delayed, and SHOULD
+   NOT terminate sessions in such cases, as the identification-tag is
+   likely to arrive soon.
 
 14.1.  RTCP MID SDES Item
 
@@ -1531,37 +1539,29 @@ Internet-Draft                Bundled media                  August 2016
    [RFC EDITOR NOTE: Please replace TBD with the assigned SDES
    identifier value.]
 
-14.2.  RTP MID Header Extension
+14.2.  RTP SDES Header Extension For MID
 
-   The payload, containing the identification-tag, of the RTP MID header
-   extension element can be encoded using either the one-byte or two-
-   byte header [RFC5285].  The identification-tag payload is UTF-8
-   encoded, as in SDP.
+   The payload, containing the identification-tag, of the RTP SDES
+   header extension element can be encoded using either the one-byte or
+   two-byte header [I-D.ietf-avtext-sdes-hdr-ext].  The identification-
+   tag payload is UTF-8 encoded, as in SDP.
 
    The identification-tag is not zero terminated.  Note, that the set of
    header extensions included in the packet needs to be padded to the
    next 32-bit boundary using zero bytes [RFC5285].
 
    As the identification-tag is included in either an RTCP SDES item or
-   an RTP header extension, or both, there should be some consideration
-   about the packet expansion caused by the identification-tag.  To
-   avoid Maximum Transmission Unit (MTU) issues for the RTP packets, the
-   header extension's size needs to be taken into account when encoding
-   the media.
+   an RTP SDES header extension, or both, there should be some
+   consideration about the packet expansion caused by the
+   identification-tag.  To avoid Maximum Transmission Unit (MTU) issues
+   for the RTP packets, the header extension's size needs to be taken
+   into account when encoding the media.
 
    It is recommended that the identification-tag is kept short.  Due to
    the properties of the RTP header extension mechanism, when using the
    one-byte header, a tag that is 1-3 bytes will result in a minimal
-   number of 32-bit words used for the RTP header extension, in case no
-   other header extensions are included at the same time.  Note, do take
-   into account that some single characters when UTF-8 encoded will
-   result in multiple octets.
-
-15.  IANA Considerations
-
-
-
-
+   number of 32-bit words used for the RTP SDES header extension, in
+   case no other header extensions are included at the same time.  Note,
 
 
 
@@ -1569,6 +1569,11 @@ Holmberg, et al.        Expires February 12, 2017              [Page 28]
 
 Internet-Draft                Bundled media                  August 2016
 
+
+   do take into account that some single characters when UTF-8 encoded
+   will result in multiple octets.
+
+15.  IANA Considerations
 
 15.1.  New SDES item
 
@@ -1588,7 +1593,7 @@ Internet-Draft                Bundled media                  August 2016
            Reference:      RFCXXXX
 
 
-15.2.  New RTP Header Extension URI
+15.2.  New RTP SDES Header Extension URI
 
    [RFC EDITOR NOTE: Please replace RFCXXXX with the RFC number of this
    document.]
@@ -1612,11 +1617,6 @@ Internet-Draft                Bundled media                  August 2016
      receives the associated SDP answer.
 
 
-15.3.  New SDP Attribute
-
-   [RFC EDITOR NOTE: Please replace RFCXXXX with the RFC number of this
-   document.]
-
 
 
 
@@ -1625,6 +1625,11 @@ Holmberg, et al.        Expires February 12, 2017              [Page 29]
 
 Internet-Draft                Bundled media                  August 2016
 
+
+15.3.  New SDP Attribute
+
+   [RFC EDITOR NOTE: Please replace RFCXXXX with the RFC number of this
+   document.]
 
    This document defines a new SDP media-level attribute, 'bundle-only',
    according to the following data:
@@ -1670,17 +1675,17 @@ Internet-Draft                Bundled media                  August 2016
    credentials might be used for all media streams specified by a BUNDLE
    group.
 
-   When the BUNDLE extension is used, the number of SSRC values within a
-   single RTP session increases, which increases the risk of SSRC
-   collision.  [RFC4568] describes how SSRC collision may weaken SRTP
-   and SRTCP encryption in certain situations.
-
 
 
 Holmberg, et al.        Expires February 12, 2017              [Page 30]
 
 Internet-Draft                Bundled media                  August 2016
 
+
+   When the BUNDLE extension is used, the number of SSRC values within a
+   single RTP session increases, which increases the risk of SSRC
+   collision.  [RFC4568] describes how SSRC collision may weaken SRTP
+   and SRTCP encryption in certain situations.
 
 17.  Examples
 
@@ -1695,11 +1700,6 @@ Internet-Draft                Bundled media                  August 2016
       address, and then selects its own BUNDLE address (the answerer
       BUNDLE address) and associates it with each bundled "m=" line
       within the BUNDLE group.
-
-
-
-
-
 
 
 
@@ -2697,6 +2697,12 @@ Internet-Draft                Bundled media                  August 2016
               Initiation Protocol (SIP)", draft-ietf-mmusic-ice-sip-
               sdp-08 (work in progress), March 2016.
 
+   [I-D.ietf-avtext-sdes-hdr-ext]
+              Westerlund, M., Burman, B., Even, R., and M. Zanaty, "RTP
+              Header Extension for RTCP Source Description Items",
+              draft-ietf-avtext-sdes-hdr-ext-07 (work in progress), June
+              2016.
+
 20.2.  Informative References
 
    [RFC3261]  Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston,
@@ -2732,12 +2738,6 @@ Appendix A.  Design Considerations
    been whether, in SDP Offers and SDP Answers, the same port value
    should be inserted in "m=" lines associated with a BUNDLE group, as
    the purpose of the extension is to negotiate the usage of a single
-   address:port combination for media specified by the "m=" lines.
-   Issues with both approaches, discussed in the Appendix have been
-   raised.  The outcome was to specify a mechanism which uses SDP Offers
-   with both different and identical port values.
-
-
 
 
 
@@ -2745,6 +2745,11 @@ Holmberg, et al.        Expires February 12, 2017              [Page 49]
 
 Internet-Draft                Bundled media                  August 2016
 
+
+   address:port combination for media specified by the "m=" lines.
+   Issues with both approaches, discussed in the Appendix have been
+   raised.  The outcome was to specify a mechanism which uses SDP Offers
+   with both different and identical port values.
 
    Below are the primary issues that have been considered when defining
    the "BUNDLE" grouping extension:
@@ -2780,11 +2785,6 @@ A.1.  UA Interoperability
        a=rtpmap:97 iLBC/8000
        m=video 10002 RTP/AVP 97
        a=rtpmap:97 H261/90000
-
-
-
-
-
 
 
 

--- a/draft-ietf-mmusic-sdp-bundle-negotiation.xml
+++ b/draft-ietf-mmusic-sdp-bundle-negotiation.xml
@@ -229,7 +229,8 @@
 			an unique identification-tag. The session-level SDP 'group' attribute
 			<xref format="default" pageno="false" target="RFC5888" /> carries a list
 			of identification-tags, identifying the "m=" lines associated with that
-			particular 'group' attribute.
+			particular 'group' attribute. The identification-tag value MUST be chosen
+      so that it does not reveal user or application information.
 		</t>
 	</section>
 
@@ -1419,14 +1420,19 @@
 			<t>
 				This section defines a new RTCP SDES item <xref format="default" pageno="false"
 				target="RFC3550"/>, 'MID', which is used to carry identification-tags within RTCP
-				SDES packets. This section also defines a new RTP header extension
-				<xref format="default" pageno="false" target="RFC5285"/>, which is used to carry
-				identification-tags in RTP packets.
+				SDES packets. This section also defines a new RTP SDES header extension
+				<xref format="default" pageno="false" target="I-D.ietf-avtext-sdes-hdr-ext"/>, which
+        is used to carry the 'MID' RTCP SDES item in RTP packets.
 			</t>
 			<t>
-				The SDES item and RTP header extension make it possible for a receiver to associate
+				The SDES item and RTP SDES header extension make it possible for a receiver to associate
 				received RTCP- and RTP packets with a specific "m=" line, with which the receiver has
 				associated an identification-tag, even if those "m=" lines are part of the same RTP session.
+        The RTP SDES header extension also ensures that the media recipient gets the identification-tag
+        upon receipt of the first decodable media and is able to associate the media with the
+        correct application.
+      </t>
+      <t>
         A media recipient informs the media sender about the identification-tag
         associated with an "m=" line through the use of an 'mid' attribute
         <xref format="default" pageno="false" target="RFC5888"/>. The media sender then
@@ -1446,9 +1452,9 @@
 				rate, the RTCP reporting interval, and the allowable overhead.
 			</t>
 			<t>
-				The RTP MID header extension SHOULD be included in some RTP packets at the start of
-				the session and whenever the SSRC changes. It might also be useful to include the
-				header extension in RTP packets that comprise access points in the media
+				The RTP SDES header extension for carrying the 'MID' RTCP SDES SHOULD be included
+        in some RTP packets at the start of the session and whenever the SSRC changes. It might
+        also be useful to include the header extension in RTP packets that comprise access points in the media
 				(e.g., with video I-frames). The exact number of RTP packets in which this header
 				extension is sent is intentionally not specified here, as it will depend on expected
 				packet loss rate and loss patterns, the overhead the application can tolerate, and
@@ -1482,11 +1488,11 @@
 					identifier value.]
 				</t>
 		</section>
-		<section title="RTP MID Header Extension" anchor="sec-receiver-id-rtp-he" toc="default">
+		<section title="RTP SDES Header Extension For MID" anchor="sec-receiver-id-rtp-he" toc="default">
 				<t>
-					The payload, containing the identification-tag, of the RTP MID header extension element
+					The payload, containing the identification-tag, of the RTP SDES header extension element
 					can be encoded using either the one-byte or two-byte header <xref format="default"
-					pageno="false" target="RFC5285"/>. The identification-tag payload is UTF-8
+					pageno="false" target="I-D.ietf-avtext-sdes-hdr-ext"/>. The identification-tag payload is UTF-8
 					encoded, as in SDP.
 				</t>
 				<t>
@@ -1495,7 +1501,7 @@
 					bytes <xref format="default" pageno="false" target="RFC5285"/>.
 				</t>
 				<t>
-					As the identification-tag is included in either an RTCP SDES item or an RTP header
+					As the identification-tag is included in either an RTCP SDES item or an RTP SDES header
 					extension, or both, there should be some consideration about the packet expansion
 					caused by the identification-tag. To avoid Maximum Transmission Unit (MTU) issues
 					for the RTP packets, the header extension's size needs to be taken into account when
@@ -1504,7 +1510,7 @@
 				<t>
 					It is recommended that the identification-tag is kept short. Due to the properties of
 					the RTP header extension mechanism, when using the one-byte header, a tag that is 1-3 bytes
-					will result in a minimal number of 32-bit words used for the RTP header extension,
+					will result in a minimal number of 32-bit words used for the RTP SDES header extension,
 					in case no other header extensions are included at the same time. Note, do take into
 					account that some single characters when UTF-8 encoded will result in multiple octets.
 				</t>
@@ -1535,7 +1541,7 @@
 				]]></artwork>
 			</figure>
 		</section>
-		<section title="New RTP Header Extension URI" anchor="sec-receiver-id-iana-rtp-uri" toc="default">
+		<section title="New RTP SDES Header Extension URI" anchor="sec-receiver-id-iana-rtp-uri" toc="default">
 			<t>
 				[RFC EDITOR NOTE: Please replace RFCXXXX with the RFC number
 				of this document.]
@@ -2313,14 +2319,15 @@ SDP Answer (2)
     <?rfc include="reference.I-D.draft-ietf-mmusic-sdp-mux-attributes-12"?>
     <?rfc include="reference.I-D.draft-ietf-mmusic-mux-exclusive-07"?>
     <?rfc include="reference.I-D.draft-ietf-mmusic-ice-sip-sdp-08"?>
+    <?rfc include="reference.I-D.draft-ietf-avtext-sdes-hdr-ext-07"?>
     </references>
 
     <references title="Informative References">
 		<?rfc include="reference.RFC.3261"?>
 		<?rfc include="reference.RFC.4568"?>
-        <?rfc include="reference.RFC.5576"?>
+    <?rfc include="reference.RFC.5576"?>
 		<?rfc include="reference.RFC.7160"?>
-        <?rfc include="reference.I-D.draft-ietf-mmusic-trickle-ice-02"?>
+    <?rfc include="reference.I-D.draft-ietf-mmusic-trickle-ice-02"?>
     </references>
 
 	<section  title="Design Considerations" toc="default">


### PR DESCRIPTION
Instead of defining a new RTP header extension for carrying the MID SDES item, the RTP SDES header extension defined in draft-ietf-avtext-sdes-hdr-ext is extended.