### PR TITLE
More changes to the RTP/m- line association chapter

### DIFF
--- a/draft-ietf-mmusic-sdp-bundle-negotiation.xml
+++ b/draft-ietf-mmusic-sdp-bundle-negotiation.xml
@@ -947,30 +947,30 @@ SDP Answer
 	</section>
 
 	<section title="Protocol Identification" anchor="sec-protocol-id" toc="default">
-            <t>
-                Each "m=" line within a BUNDLE group MUST use the same transport-
-                layer protocol. If bundled "m=" lines use different protocols on top
-                of the transport-layer protocol, there MUST exist a publicly
-                available specification which describes a mechanism, for this
-                particular protocol combination, how to associate received data
-                with the correct protocol.
-			</t>
-            <t>
-                In addition, if received data can be associated with more than
-                one bundled "m=" line, there MUST exist a publicly available
-                specification which describes a mechanism for associating the
-                received data with the correct "m=" line.
-			</t>
-            <t>
-                This document describes a mechanism to identify the
-                protocol of received data among the STUN, DTLS and SRTP protocols
-                (in any combination), when UDP is used as transport-layer protocol,
-                but does not describe how to identify different protocols transported on
-                DTLS. While the mechanism is generally applicable to other protocols and
-                transport-layer protocols, any such use requires further specification around
-                how to multiplex multiple protocols on a given transport-layer protocol,
-                and how to associate received data with the correct protocols.
-            </t>
+    <t>
+      Each "m=" line within a BUNDLE group MUST use the same transport-
+      layer protocol. If bundled "m=" lines use different protocols on top
+      of the transport-layer protocol, there MUST exist a publicly
+      available specification which describes a mechanism, for this
+      particular protocol combination, how to associate received data
+      with the correct protocol.
+    </t>
+    <t>
+      In addition, if received data can be associated with more than
+      one bundled "m=" line, there MUST exist a publicly available
+      specification which describes a mechanism for associating the
+      received data with the correct "m=" line.
+    </t>
+    <t>
+      This document describes a mechanism to identify the
+      protocol of received data among the STUN, DTLS and SRTP protocols
+      (in any combination), when UDP is used as transport-layer protocol,
+      but does not describe how to identify different protocols transported on
+      DTLS. While the mechanism is generally applicable to other protocols and
+      transport-layer protocols, any such use requires further specification around
+      how to multiplex multiple protocols on a given transport-layer protocol,
+      and how to associate received data with the correct protocols.
+    </t>
 		<section anchor="sec-packets-id-sds" title="STUN, DTLS, SRTP" toc="default">
 			<t>
 				Section 5.1.2 of <xref format="default" pageno="false" target="RFC5764"/> describes a
@@ -1118,10 +1118,11 @@ SDP Answer
         </t>
         <t>
           If an offerer and answerer is not able to associate an RTP stream with an "m=" line (using
-          the mechanisms described in this section, or using other appropriate mechanism), it
-          SHOULD drop the RTP/RTCP packets associated with the RTP stream, once non-stream specific
-          processing (e.g., related to congestion control) of the packets have occurred.
-          Note that RTCP packets might be associated with multiple RTP streams.
+          the mechanisms described in this section, or using other appropriate mechanism, e.g, based
+          on the payload type value if it is unique to a single “m=” line), it MUST either drop the
+          RTP/RTCP packets associated with the RTP stream, or process them in an application specific
+          manner, once non-stream specific processing (e.g., related to congestion control) of the packets
+          have occurred. Note that RTCP packets might be associated with multiple RTP streams.
         </t>
 		</section>
 
@@ -1734,10 +1735,10 @@ SDP Answer
 			The security considerations defined in <xref format="default"
 			pageno="false" target="RFC3264"/> and <xref format="default"
 			pageno="false" target="RFC5888"/> apply to the BUNDLE
-            extension. Bundle does not change which information
-            flows over the network but only changes which addresses and
-            ports that information is flowing on and thus has very little
-            impact on the security of the RTP sessions.
+      extension. Bundle does not change which information
+      flows over the network but only changes which addresses and
+      ports that information is flowing on and thus has very little
+      impact on the security of the RTP sessions.
 		</t>
 		<t>
 			When the BUNDLE extension is used, a single set of security credentials

--- a/draft-ietf-mmusic-sdp-bundle-negotiation.xml
+++ b/draft-ietf-mmusic-sdp-bundle-negotiation.xml
@@ -1066,83 +1066,81 @@ SDP Answer
 			</section>
 		</section>
 
-		<section anchor="sec-rtp-pt" title="Associating RTP/RTCP Packets With Correct SDP Media Description" toc="default">
+		<section anchor="sec-rtp-pt" title="Associating RTP/RTCP Streams With Correct SDP Media Description" toc="default">
 				<t>
-					There are multiple mechanisms that can be used by an endpoint in
-					order to associate received RTP/RTCP packets with a bundled "m=" line.
-					Such mechanisms include using the payload type value carried inside the
-					RTP packets, the SSRC values carried inside the RTP packets, and other
-					"m=" line specific information carried inside the RTP packets.
-				</t>
-				<t>
-					As all RTP/RTCP packets associated with a BUNDLE group are received (and sent)
-					using single address:port combinations, the local address:port combination cannot
-					be used to associate received RTP packets with the correct "m=" line.
-				</t>
-				<t>
-					As described in [<xref format="default" pageno="false" target="sec-rtp-sessions-pt"/>],
-					the same payload type value might be used inside RTP packets described by
-					multiple "m=" lines. In such cases, the payload type value cannot be used to
-					associate received RTP packets with the correct "m=" line.
-				</t>
-				<t>
-                    An offerer and answerer can inform each other which SSRC values they will use
-                    for RTP and RTCP by using the SDP 'ssrc' attribute <xref format="default" pageno="false"
-                    target="RFC5576"/>. To allow for proper association with this mechanism, the 'ssrc'
-                    attribute needs to be associated with each "m=" line that shares a
-                    payload type with any other "m=" line in the same bundle.
-                    As the SSRC values will be carried inside the RTP/RTCP packets, the offerer and
-                    answerer can then use that information to associate received RTP packets with
-                    the correct "m=" line. However, an offerer will not know which SSRC values the
-                    answerer will use until it has received the answer providing that information.
-                    Due to this, before the offerer has received the answer, the offerer will not be
-                    able to associate received RTP packets with the correct "m=" line using the
-                    SSRC values. In addition, the SSRC value can change during the session, and
-                    values that were not provided using the SDP 'ssrc' attribute may be used.
-				</t>
-				<t>
-					In order for an offerer and answerer to always be able to associate received
-					RTP packets with the correct "m=" line, an offerer and answerer using
-					the BUNDLE extension MUST support the mechanism defined in <xref format="default"
-					pageno="false" target="sec-receiver-id"/>, where the remote endpoint inserts the
-					identification-tag associated with an "m=" line in RTP and RTCP packets
-					associated with that "m=" line.
-				</t>
-        <t>
-          Once an offerer or answerer recieves an RTP/RTCP packet carrying an identification-tag
-          and an SSRC value, it associates the SSRC value with the "m=" line associated with the
-          identification-tag. Later, when an offerer or answerer receives an RTP or RTCP packet
-          that does not carry the identification-tag, it can associate the packet with the
-          correct "m=" line using the SSRC value. Note that multiple SSRC values may end up
-          being associated with the same "m=" line.
+          As described in <xref format="default" pageno="false" target="RFC3550"/>, RTP/RTCP packets
+          are associated with RTP streams. Each RTP stream is identified by an SSRC value, and each
+          RTP/RTCP packet carries an SSRC value that is used to associate the packet with the correct
+          RTP stream (an RTCP packet can carry multiple SSRC values, and might therefore be associated
+          with multiple RTP streams).
         </t>
         <t>
-          If an offerer or answerer is not able to associate an RTP packet with the correct
-          "m=" line using the SSRC value, the offerer or answerer can check whether the association
-          can be done using the payload type value (in case the payload type value is unique for a
-          given "m=" line within the BUNDLE group), or using other appropriate mechanisms. After
-          all appropriate mechanisms supported by the offerer or answerer have been tried, if it is
-          not possible to associate a packet with the correct "m=" line, the packet SHOULD be dropped
-          after having been processed as received by the RTCP layer.
+          In order to be able to process received RTP/RTCP packets correctly it must be possible
+          to associate an RTP stream with the correct "m=" line, as the "m=" line and SDP attributes
+          associated with the "m=" line contain information needed to process the packets.
+        </t>
+        <t>
+					As all RTP streams associated with a BUNDLE group are using the same
+					address:port combination for sending and receiving RTP/RTCP packets, the
+          local address:port combination cannot be used to associate an RTP stream
+          with the correct "m=" line. In addition, multiple RTP streams might be
+          associated with the same "m=" line.
+				</t>
+        <t>
+					Also, as described in [<xref format="default" pageno="false" target="sec-rtp-sessions-pt"/>],
+					the same payload type value might be used by multiple RTP streams, in which case the payload
+          type value cannot be used to associate an RTP stream with the correct "m=" line.
+				</t>
+				<t>
+          An offerer and answerer can inform each other which SSRC values they will use
+          for an RTP stream by using the SDP 'ssrc' attribute <xref format="default" pageno="false"
+          target="RFC5576"/>. However, an offerer will not know which SSRC values the
+          answerer will use until the offerer has received the answer providing that information.
+          Due to this, before the offerer has received the answer, the offerer will not be
+          able to associate an RTP stream with the correct "m=" line using the SSRC value associated
+          with the RTP stream. In addition, the offerer and answerer may start using new SSRC
+          values mid-session, without informing each other using the SDP 'ssrc' attribute.
+				</t>
+				<t>
+					In order for an offerer and answerer to always be able to associate an RTP stream
+					with the correct "m=" line, the offerer and answerer using the BUNDLE extension MUST
+          support the mechanism defined in <xref format="default" pageno="false" target="sec-receiver-id"/>,
+          where the offerer and answerer insert the identification-tag (provided by the remote peer)
+          associated with an "m=" line in RTP and RTCP packets associated with a BUNDLE group.
+				</t>
+        <t>
+          Once an offerer or answerer recieve an RTP/RTCP packet carrying an identification-tag
+          and an SSRC value (an RTCP packet might carry multiple identification-tags and SSRC values), it creates a
+          mapping between the SSRC value and the identification-tag, in order to associate the RTP stream
+          with the "m=" line associated with the identification-tag. Note that the mapping might
+          change mid-session if, for a given SSRC value, a different identification-tag is provided in
+          an RTP/RTCP packet.
+        </t>
+        <t>
+          If an offerer and answerer is not able to associate an RTP stream with an "m=" line (using
+          the mechanisms described in this section, or using other appropriate mechanism), it
+          SHOULD drop the RTP/RTCP packets associated with the RTP stream, once non-stream specific
+          processing (e.g., related to congestion control) of the packets have occurred.
+          Note that RTCP packets might be associated with multiple RTP streams.
         </t>
 		</section>
 
 		<section title="RTP/RTCP Multiplexing" anchor="sec-rtprtcp-mux" toc="default">
-                <t>
-                    Within a BUNDLE group, the offerer and answerer MUST enable
-                    RTP/RTCP multiplexing <xref format="default" pageno="false"
-                    target="RFC5761"/> for the RTP-based media specified by
-                    the BUNDLE group.
-                </t>
-                <t>
-                    When RTP/RTCP multiplexing is enabled, the same address:port
-                    combination will be used for sending all RTP packets
-                    and the RTCP packets associated with the BUNDLE group. Each endpoint
-                    will send the packets towards the BUNDLE address of the other
-                    endpoint. The same address:port combination MAY be used
-                    for receiving RTP packets and RTCP packets.
-                </t>
-			<section title="SDP Offer/Answer Procedures" anchor="sec-rtprtcp-mux-oa" toc="default">
+        <t>
+          Within a BUNDLE group, the offerer and answerer MUST enable
+          RTP/RTCP multiplexing <xref format="default" pageno="false"
+          target="RFC5761"/> for the RTP-based media specified by
+          the BUNDLE group.
+        </t>
+        <t>
+          When RTP/RTCP multiplexing is enabled, the same address:port
+          combination will be used for sending all RTP packets
+          and the RTCP packets associated with the BUNDLE group. Each endpoint
+          will send the packets towards the BUNDLE address of the other
+          endpoint. The same address:port combination MAY be used
+          for receiving RTP packets and RTCP packets.
+        </t>
+			  <section title="SDP Offer/Answer Procedures" anchor="sec-rtprtcp-mux-oa" toc="default">
 					<t>
 						This section describes how an offerer and answerer use the
             SDP 'rtcp-mux' attribute <xref format="default" pageno="false"


### PR DESCRIPTION
Instead of talking about associating RTP packets with m- lines, the text now talks about associating RTP streams with m- lines.